### PR TITLE
update Dockerfile and pom.xml 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,12 @@ COPY pom.xml /home/app
 #Personal access tokens are intended to access GitHub resources on behalf of yourself.
 RUN echo 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 > /home/app/key.json
 
-RUN mvn -f /home/app/pom.xml clean package
+RUN mvn -f /home/app/pom.xml clean package -DskipTests
 
 #
 # Package stage
 #
-FROM openjdk:11-jre-slim
+FROM adoptopenjdk/openjdk11:jre-11.0.11_9-alpine
 COPY --from=build /home/app/target/swagger-0.0.1-SNAPSHOT.jar /usr/local/lib/demo.jar
 
 EXPOSE 8080

--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,7 @@
 			<version>2.8.0</version>
 		</dependency>
 		<dependency>
-		    <groupId>org.springframework</groupId>
-		    <artifactId>spring-web</artifactId>
-		    <version>5.3.19</version>
-		</dependency>		
-		<dependency>
+
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<version>42.2.0</version>


### PR DESCRIPTION
Updated base image as the previous OpenJDK image is deprecated, and skipped tests during Docker build for faster execution. Removed redundant dependency from pom.xml to make the application runnable.